### PR TITLE
Import `ThemeProvider` instead of `MuiThemeProvider`

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Route, BrowserRouter as Router } from 'react-router-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import MuiThemeProvider from '@material-ui/core/styles/MuiThemeProvider';
+import { ThemeProvider as MuiThemeProvider } from '@material-ui/core/styles';
 import theme from './theme';
 import Home from './Home';
 import About from './About';


### PR DESCRIPTION
Related to https://github.com/mui-org/material-ui/issues/17900 , it seems to use `ThemeProvider` to avoid the following error on the browser.

```
Material-UI: you have imported a private module.

Please replace the '@material-ui/core/styles/MuiThemeProvider' import with:
`import { ThemeProvider as MuiThemeProvider } from '@material-ui/core/styles';`
```