### PR TITLE
fix  'ThemeProvider' is not exported

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Route, BrowserRouter as Router } from 'react-router-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { ThemeProvider as MuiThemeProvider } from '@material-ui/core/styles';
+import MuiThemeProvider from "@material-ui/core/styles/MuiThemeProvider";
 import theme from './theme';
 import Home from './Home';
 import About from './About';


### PR DESCRIPTION
 'ThemeProvider' is not exported from '@material-ui/core/styles' (imported as 'MuiThemeProvider').

see 
https://stackoverflow.com/questions/58432694/cannot-import-material-ui-core-styles-muithemeprovider