### PR TITLE
Upgrade rules_version to 2 in firestore.rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,3 +1,4 @@
+rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /users/{userId} {
@@ -9,4 +10,3 @@ service cloud.firestore {
     }
   }
 }
-


### PR DESCRIPTION
During deployment, the following warning is displayed.

```
⚠  [W] undefined:undefined - Ruleset uses old version (version [1]). Please update to the latest version (version [2]).
```

If `rules_version = '2';` is specified, the warning disappears.
https://stackoverflow.com/questions/60847344/how-to-upgrade-to-firebase-storage-rules-v2

Here's the difference between version 1 and 2.
They behave the same in the current configuration.
https://firebase.google.com/docs/firestore/security/rules-structure#version-2